### PR TITLE
Logging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,6 @@
+
+### Setup
+
 Create a Configmap from the custom Go template provided. This configuration will be mounted into the Pod and generated each time a new service is added.
 
 ```
@@ -10,8 +13,28 @@ Get the value of the environment namespace (OpenShift project) via the command `
 ```
 sudo oc new-app -f router-template.json -n <environment-project-namespace> --param=ENVIRONMENT_NAMESPACE=<environment-project-namespace>
 ```
+
 For example :
 
 ```
 sudo oc new-app -f router-template.json -n rhmap-rhmap-myrouter --param=ENVIRONMENT_NAMESPACE=rhmap-rhmap-myrouter
+```
 
+#### Logging
+
+By default, the HAProxy image has no logging enabled and requires a syslog server to send the logs to. There is an rsyslog server template which will create a "logger" Pod and Service which can be used when HAProxy logging is required. To run the logger :
+
+```
+sudo oc new-app -f rsyslog/syslog-server.json -n rhmap-rhmap-myrouter
+```
+
+The container needs to be run as root, so to allow this run the following command where rhmap-rhmap-myrouter is <environment-project-namespace> as before :
+
+```
+sudo oadm policy add-scc-to-user anyuid system:serviceaccount:rhmap-rhmap-myrouter:logger
+```
+
+The environment-proxy Pod needs to be aware that logging has been enabled. This can be done in two ways
+
+1. If the Pod is already running, add the ROUTER_SYSLOG_ADDRESS environment variable as logger:514
+2. If the logger Pod is created first, when creating the HAProxy application, append the ROUTER_SYSLOG_ADDRESS=logger:514 to the command shown in setup.

--- a/haproxy-config.template
+++ b/haproxy-config.template
@@ -8,6 +8,7 @@
 global
   # maxconn 4096
   daemon
+  log logger:514 local0
   ca-base /etc/ssl
   crt-base /etc/ssl
   stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
@@ -87,6 +88,8 @@ listen stats :1936
 frontend public
   bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
   mode http
+  option httplog
+  log global
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
@@ -129,6 +132,7 @@ backend openshift_default
 # Plain http backend but request is TLS, terminated at edge
 backend be_edge_http_{{$cfgIdx}}
   mode http
+  log global
   option redispatch
   option forwardfor
   balance leastconn

--- a/haproxy-config.template
+++ b/haproxy-config.template
@@ -8,7 +8,9 @@
 global
   # maxconn 4096
   daemon
-  log logger:514 local0
+{{ with (env "ROUTER_SYSLOG_ADDRESS" "") }}
+  log {{.}} local1 {{env "ROUTER_LOG_LEVEL" "warning"}}
+{{ end }}
   ca-base /etc/ssl
   crt-base /etc/ssl
   stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
@@ -88,8 +90,10 @@ listen stats :1936
 frontend public
   bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
   mode http
+{{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
   option httplog
   log global
+{{ end }}
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
@@ -132,7 +136,10 @@ backend openshift_default
 # Plain http backend but request is TLS, terminated at edge
 backend be_edge_http_{{$cfgIdx}}
   mode http
+{{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
+  option httplog
   log global
+{{ end }}
   option redispatch
   option forwardfor
   balance leastconn

--- a/router-template.json
+++ b/router-template.json
@@ -130,16 +130,20 @@
                                     {
                                       "name": "TEMPLATE_FILE",
                                       "value": "/var/lib/haproxy/conf/custom/haproxy-config.template"
+                                    },
+                                    {
+                                      "name": "ROUTER_SYSLOG_ADDRESS",
+                                      "value": "${ROUTER_SYSLOG_ADDRESS}"
+                                    },
+                                    {
+                                      "name": "ROUTER_LOG_LEVEL",
+                                      "value": "${ROUTER_LOG_LEVEL}"
                                     }
                                 ],
                                 "volumeMounts": [
                                   {
                                     "name": "config-volume",
                                     "mountPath": "/var/lib/haproxy/conf/custom"
-                                  },
-                                  {
-                                    "name": "logger",
-                                    "mountPath": "/dev/log"
                                   }
                                 ],
                                 "resources": {},
@@ -152,10 +156,6 @@
                             "configMap": {
                               "name": "customrouter"
                             }
-                          },
-                          {
-                            "name": "logger",
-                            "emptyDir": {}
                           }
                         ],
                         "serviceAccountName": "router",
@@ -263,10 +263,20 @@
         "generate": "expression",
         "from": "[a-zA-Z0-9]{15}"
       },
-       {
+      {
         "name": "IMAGE_VERSION",
         "description": "The OpenShift router image version which should be deployed",
         "value": "openshift/origin-haproxy-router:v1.3.1"
+      },
+      {
+        "name": "ROUTER_SYSLOG_ADDRESS",
+        "description": "The hostname or address of the syslog server to log to",
+        "value": ""
+      },
+      {
+        "name": "ROUTER_LOG_LEVEL",
+        "description": "The hostname or address of the syslog server to log to",
+        "value": "debug"
       }
   ]
 }

--- a/router-template.json
+++ b/router-template.json
@@ -136,6 +136,10 @@
                                   {
                                     "name": "config-volume",
                                     "mountPath": "/var/lib/haproxy/conf/custom"
+                                  },
+                                  {
+                                    "name": "logger",
+                                    "mountPath": "/dev/log"
                                   }
                                 ],
                                 "resources": {},
@@ -148,6 +152,10 @@
                             "configMap": {
                               "name": "customrouter"
                             }
+                          },
+                          {
+                            "name": "logger",
+                            "emptyDir": {}
                           }
                         ],
                         "serviceAccountName": "router",

--- a/rsyslog/Dockerfile
+++ b/rsyslog/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7
+
+USER root
+
+RUN  yum -y install rsyslog && \
+	 yum clean all && \
+	 echo "" > /etc/rsyslog.d/listen.conf
+
+COPY rsyslog.conf /etc/rsyslog.conf
+
+EXPOSE 514
+
+CMD ["/usr/sbin/rsyslogd", "-n"]

--- a/rsyslog/rsyslog.conf
+++ b/rsyslog/rsyslog.conf
@@ -1,0 +1,38 @@
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+$ModLoad omstdout.so       # provide messages to stdout
+
+# Provides UDP syslog reception
+$ModLoad imudp
+$UDPServerRun 514
+
+# Provides TCP syslog reception
+$ModLoad imtcp
+$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+$WorkDirectory /var/lib/rsyslog
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging off
+
+
+#### RULES ####
+
+# Actions
+*.* :omstdout:             # send everything to stdout
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+

--- a/rsyslog/syslog-server.json
+++ b/rsyslog/syslog-server.json
@@ -1,0 +1,116 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {},
+    "objects": [
+        {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "logger"
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "logger",
+                "labels": {
+                    "logger": "rsyslog"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "maxUnavailable": "25%",
+                        "maxSurge": 0,
+                        "updatePercent": -25
+                    },
+                    "resources": {}
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "test": false,
+                "selector": {
+                    "logger": "rsyslog"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "logger": "rsyslog"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "rsyslog",
+                                "image": "docker.io/philipgough/rsyslog",
+                                "ports": [
+                                    {
+                                        "name": "rsyslog-udp",
+                                        "containerPort": 514,
+                                        "protocol": "UDP"
+                                    },
+                                    {
+                                        "name": "rsyslog-tcp",
+                                        "containerPort": 514,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                ],
+                                "resources": {},
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "volumes": [
+                        ],
+                        "serviceAccountName": "logger",
+                        "serviceAccount": "logger",
+                        "securityContext": {}
+                    }
+                }
+            },
+            "status": {}
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "logger",
+                "labels": {
+                    "logger": "rsyslog"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "logger-tcp",
+                        "protocol": "TCP",
+                        "port": 514,
+                        "targetPort": 514
+                    },
+                    {
+                        "name": "logger-udp",
+                        "protocol": "UDP",
+                        "port": 514,
+                        "targetPort": 514
+                    }
+                ],
+                "selector": {
+                    "logger": "rsyslog"
+                }
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        }
+    ],
+    "parameters": [
+  ]
+}


### PR DESCRIPTION
#### Motivation

Going forward we need some logging for HAProxy while we work on this wildcard cert issue. By default, HAProxy image doesn't log, and logging can only be enabled to syslog server.

#### Solution
Create a Pod running rsyslog server as a Service and update the custom Golang template which will be mounted a s a Configmap to read env vars and forward logging to this Service when required.

Note: This is for dev purposes at the moment only so the logging Pod needs to run as root. If we see value in this for a customer we will need to revisit that issue

@wtrocki @laurafitzgerald 