### PR TITLE
Remove the need for admin to set cluster role binding on service account

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,13 +5,13 @@ oc create configmap customrouter --from-file=haproxy-config.template
 ```
 
 
-Get the value of the environment namespace (OpenShift project) via the command `oc project` and use this in the placeholders in the following command:
+Get the value of the environment namespace (OpenShift project name) via the command `oc project`, and the Service account that is created in the project by default `oc get sa` (in format rhmap-user-<env-name>). Use these values in the placeholders in the following command:
 
 ```
-sudo oc new-app -f router-template.json -n <environment-project-namespace> --param=ENVIRONMENT_NAMESPACE=<environment-project-namespace>
+sudo oc new-app -f router-template.json -n <environment-project-namespace> --param=ENVIRONMENT_NAMESPACE=<environment-project-namespace> --param=PROJECT_SERVICE_ACCOUNT=<environment-project-environment-name>
 ```
 For example :
 
 ```
-sudo oc new-app -f router-template.json -n rhmap-rhmap-myrouter --param=ENVIRONMENT_NAMESPACE=rhmap-rhmap-myrouter
+sudo oc new-app -f router-template.json -n rhmap-rhmap-myEnvironment --param=ENVIRONMENT_NAMESPACE=rhmap-rhmap-myEnvironment --param=PROJECT_SERVICE_ACCOUNT=rhmap-user-myEnvironment
 ```

--- a/router-template.json
+++ b/router-template.json
@@ -4,35 +4,6 @@
     "metadata": {},
     "objects": [
         {
-            "kind": "ServiceAccount",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "router"
-            }
-        },
-        {
-            "kind": "ClusterRoleBinding",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${ENVIRONMENT_NAMESPACE}-proxy-role"
-            },
-            "userNames": [
-                "system:serviceaccount:${ENVIRONMENT_NAMESPACE}:router"
-            ],
-            "groupNames": null,
-            "subjects": [
-                {
-                    "kind": "ServiceAccount",
-                    "namespace": "${ENVIRONMENT_NAMESPACE}",
-                    "name": "router"
-                }
-            ],
-            "roleRef": {
-                "kind": "ClusterRole",
-                "name": "system:router"
-            }
-        },
-        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -116,6 +87,10 @@
                                         "value": "${ENVIRONMENT_NAMESPACE}"
                                     },
                                     {
+                                        "name": "NAMESPACE_SERVICE_ACCOUNT",
+                                        "value": "${NAMESPACE_SERVICE_ACCOUNT}"
+                                    },
+                                    {
                                         "name": "STATS_PASSWORD",
                                         "value": "${STATS_PASSWORD}"
                                     },
@@ -150,8 +125,8 @@
                             }
                           }
                         ],
-                        "serviceAccountName": "router",
-                        "serviceAccount": "router",
+                        "serviceAccountName": "${NAMESPACE_SERVICE_ACCOUNT}",
+                        "serviceAccount": "${NAMESPACE_SERVICE_ACCOUNT}",
                         "hostNetwork": false,
                         "securityContext": {}
                     }
@@ -238,6 +213,11 @@
       {
         "name": "ENVIRONMENT_NAMESPACE",
         "description": "The namespace the router should be limited to",
+        "required": true
+      },
+      {
+        "name": "NAMESPACE_SERVICE_ACCOUNT",
+        "description": "The service account generated with the environment project",
         "required": true
       },
       {


### PR DESCRIPTION
### Motivation
We might like to be able to deploy the router into an environment project when an environment project is created (currently via supercore).

However the user wont have permissions to create a cluster role binding so we need a workaround.

#### Solution
Use the service account that gets created in the environment project since it can already read services at a project level. Pass this as param to the template

Note --> Downside to this is VERY noisy router logs (complaining about viewing services and routes at a cluster level since we have no cluster role binding)